### PR TITLE
fix(hardhat ignition): Fix artifact handling in ignitiion

### DIFF
--- a/packages/hardhat-resolc/src/index.ts
+++ b/packages/hardhat-resolc/src/index.ts
@@ -57,7 +57,7 @@ extendConfig((config, userConfig) => {
 extendEnvironment((hre) => {
     if (hre.network.config.polkavm) {
         hre.network.polkavm = hre.network.config.polkavm;
-
+        
         let artifactsPath = hre.config.paths.artifacts;
         if (!artifactsPath.endsWith('-pvm')) {
             artifactsPath = `${artifactsPath}-pvm`;
@@ -330,8 +330,10 @@ subtask(TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS, async (taskArgs, hre, runSuper) 
     }
 
     const artifactsDir = hre.config.paths.artifacts;
+
+    if (artifactsDir.slice(-4) !== '-pvm') fs.rmSync(artifactsDir, { recursive: true });
+
     const cacheDir = hre.config.paths.cache;
 
-    fs.rmSync(artifactsDir, { recursive: true });
-    fs.rmSync(cacheDir, { recursive: true });
+    if (cacheDir.slice(-4) !== '-pvm') fs.rmSync(cacheDir, { recursive: true });
 });

--- a/packages/hardhat-resolc/src/index.ts
+++ b/packages/hardhat-resolc/src/index.ts
@@ -325,7 +325,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT, async (taskArgs, hre, runSuper
 });
 
 subtask(TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS, async (taskArgs, hre, runSuper) => {
-    if (hre.network.polkavm) {
+    if (!hre.network.polkavm) {
         return await runSuper(taskArgs);
     }
 

--- a/packages/hardhat-resolc/src/type-extensions.ts
+++ b/packages/hardhat-resolc/src/type-extensions.ts
@@ -16,7 +16,7 @@ declare module 'hardhat/types/config' {
     }
 
     interface HttpNetworkUserConfig {
-        polkavm?: HttpNetworkConfig
+        polkavm?: boolean
     }
 
     interface HardhatNetworkConfig {
@@ -28,7 +28,7 @@ declare module 'hardhat/types/config' {
     }
 
     interface NetworksConfig {
-        polkavm?: HttpNetworkConfig
+        polkavm?: boolean
     }
 }
 

--- a/packages/hardhat-revive-node/src/index.ts
+++ b/packages/hardhat-revive-node/src/index.ts
@@ -32,6 +32,7 @@ import { PolkaVMNodePluginError } from './errors';
 import { interceptAndWrapTasksWithNode } from './core/global-interceptor';
 import { runScriptWithHardhat } from './core/script-runner';
 import { AdapterConfig, NodeConfig, RpcServer } from './types';
+import './type-extensions';
 
 task(TASK_RUN).setAction(async (args, hre, runSuper) => {
     if (!hre.network.polkavm || hre.network.name !== HARDHAT_NETWORK_NAME) {


### PR DESCRIPTION
### Description
`ignition` was looking for artifacts that weren't there, and therefore causing the deployment to fail. Now we have updated the artifacts removal in `hardhat-resolc` to correct this.

### Steps to reproduce

Start a new hardhat ts project:
```bash
npx hardhat init
```

Update the `hardhat.config.ts` file as follows:
```ts
import "@nomicfoundation/hardhat-network-helpers";
import "@nomicfoundation/hardhat-chai-matchers";
import "@nomicfoundation/hardhat-ethers";
import "hardhat-gas-reporter";
import '@nomicfoundation/hardhat-ignition';
import <path-to-hardhat-resolc>;
import <path-to-hardhat-node>;

import { HardhatUserConfig } from "hardhat/config";

const config: HardhatUserConfig = {
  solidity: "0.8.28",
  resolc: {
    compilerSource: 'binary',
    settings: {
      optimizer: {
        enabled: true,
        runs: 400,
      },
      evmVersion: "istanbul",
      compilerPath: "resolc",
      standardJson: true,
    },
  },
  networks: {
    hardhat: {
      polkavm: true,
      nodeConfig: {
        nodeBinaryPath: <path-to-node>,
        rpcPort: 8000,
        dev: true,
      },
      adapterConfig: {
        adapterBinaryPath: <path-to-rpc>,
        dev: true,
      },
    },
    polkavm: {
      polkavm: true,
      url: `http://127.0.0.1:8545`
    },
  },

};

export default config;
```
Now we need to change the deployment param inside the `Lock` module, because of [this](https://github.com/paritytech/polkadot-sdk/pull/7792) so it looks like this:
```ts
const JAN_1ST_2030 = 18934560000000;
```

Then run ignition:
```bash
npx hardhat ignition deploy ./ignition/modules/Lock.ts --network polkavm
```
And you should see an output simmilar to this:
```bash
✔ Confirm deploy to network polkavm (420420420)? … yes
Compiling 1 Solidity file

Warning: It looks like you are using '<address payable>.send/transfer(<X>)'.
Using '<address payable>.send/transfer(<X>)' is deprecated and strongly discouraged!
The resolc compiler uses a heuristic to detect '<address payable>.send/transfer(<X>)' calls,
which disables call re-entrancy and supplies all remaining gas instead of the 2300 gas stipend.
However, detection is not guaranteed. You are advised to carefully test this, employ
re-entrancy guards or use the withdrawal pattern instead!
Learn more on https://docs.soliditylang.org/en/latest/security-considerations.html#reentrancy
and https://docs.soliditylang.org/en/latest/common-patterns.html#withdrawal-from-contracts

--> contracts/Lock.sol

Successfully compiled 1 Solidity file
Hardhat Ignition 🚀

Deploying [ LockModule ]

Batch #1
  Executed LockModule#Lock

[ LockModule ] successfully deployed 🚀

Deployed Addresses

LockModule#Lock - 0x3ed62137c5DB927cb137c26455969116BF0c23Cb
```
Rel: https://github.com/paritytech/contract-issues/issues/25