### PR TITLE
fix(hardhat-ignition): updated bytecode format to match ignition's

### DIFF
--- a/packages/hardhat-resolc/src/index.ts
+++ b/packages/hardhat-resolc/src/index.ts
@@ -145,8 +145,8 @@ subtask(
             contractName,
             sourceName,
             abi: contractOutput.abi,
-            bytecode,
-            deployedBytecode: bytecode,
+            bytecode: `0x${bytecode}`,
+            deployedBytecode: `0x${bytecode}`,
             linkReferences: {},
             deployedLinkReferences: {},
         };


### PR DESCRIPTION
### Description
This changes the bytecode format to have a hex prefix to match the regular hardhat artifact's format.

Rel: https://github.com/paritytech/contract-issues/issues/25