### PR TITLE
fix(hardhat-node): retrieve chainId from chain

### DIFF
--- a/packages/hardhat-revive-node/README.md
+++ b/packages/hardhat-revive-node/README.md
@@ -107,6 +107,9 @@ const config: HardhatUserConfig = {
 In this example, since we are forking a live chain, we do not need to specify the
 node binary path.
 
+**NOTE** The `chainId` parameter inside `networks.hardhat` will be overwritten by
+the value the plugin retrieves from the chain it's connected to.
+
 Pleaser refer to the [CommandArguments](/packages/hardhat-revive-node/src/types.ts#L28)
 type to see the available configuration options.
 


### PR DESCRIPTION
### Description 
This changes the behavior of the chainId setup. It now retrieves the `chainId` retrieved from the chain instead of the one defined in the `hardhat.config`, in order to avoid this error:
```bash
HardhatError: HH101: Hardhat was set to use chain id 31337, but connected to a chain with id 420420421.
```
Closes #31 