### PR TITLE
fix(bug): fix relative imports

### DIFF
--- a/packages/hardhat-resolc/src/compile/binary.ts
+++ b/packages/hardhat-resolc/src/compile/binary.ts
@@ -22,6 +22,7 @@ export async function compileWithBinary(
 
     let parsedOutput: CompiledOutput = { contracts: {}, sources: {}, errors: [], version: '', long_version: '', revive_version: '' };
     if (batchSize) {
+        console.log('`batchSize` is an experimental feature and may fail when used with smart contracts that employ relative imports.');
         let selectedContracts: ContractBatch = {};
         for (let i = 0; i < ordered.length; i += batchSize!) {
             selectedContracts = ordered.slice(i, i + batchSize).reduce((acc, key) => {

--- a/packages/hardhat-resolc/src/compile/binary.ts
+++ b/packages/hardhat-resolc/src/compile/binary.ts
@@ -10,7 +10,7 @@ export async function compileWithBinary(
     const {
         compilerPath,
         batchSize
-    } = config.settings;
+    } = config.settings!;
 
     const commands = extractCommands(config);
 

--- a/packages/hardhat-resolc/src/compile/npm.ts
+++ b/packages/hardhat-resolc/src/compile/npm.ts
@@ -2,11 +2,12 @@ import { exec as execCb } from 'child_process';
 import { promisify } from 'util';
 import { compile, resolveInputs } from '@parity/revive';
 import type { SolcOutput } from "@parity/revive";
+import { CompilerInput } from 'hardhat/types';
 
 const exec = promisify(execCb);
 
-export async function compileWithNpm(sources: any): Promise<SolcOutput> {
-    sources = resolveInputs(sources);
+export async function compileWithNpm(input: CompilerInput): Promise<SolcOutput> {
+    const sources = resolveInputs(input.sources);
 
     const out = compile(sources);
 

--- a/packages/hardhat-resolc/src/utils.ts
+++ b/packages/hardhat-resolc/src/utils.ts
@@ -41,10 +41,10 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
 
   const settings = compiler.settings || {};
 
-  compiler.settings = { ...settings, optimizer: { ...resolc.settings.optimizer }, evmVersion: resolc.settings.evmVersion };
+  compiler.settings = { ...settings, optimizer: { ...resolc.settings?.optimizer }, evmVersion: resolc.settings?.evmVersion };
 
-  const forceEVMLA = resolc.settings.forceEVMLA && resolc.compilerSource === 'binary';
-  resolc.settings.forceEVMLA = forceEVMLA;
+  const forceEVMLA = resolc.settings?.forceEVMLA && resolc.compilerSource === 'binary';
+  resolc.settings!.forceEVMLA = forceEVMLA;
 
   const [major, minor] = getVersionComponents(compiler.version);
   if (major === 0 && minor < 7 && resolc.compilerSource === 'binary') {
@@ -69,7 +69,7 @@ export function pluralize(n: number, singular: string, plural?: string) {
 
 function extractYulCommands(config: ResolcConfig, commandArgs: string[]): string[] {
 
-  const settings = config.settings;
+  const settings = config.settings!;
 
   commandArgs.push(`--yul`);
 
@@ -120,7 +120,7 @@ function extractYulCommands(config: ResolcConfig, commandArgs: string[]): string
 }
 
 function extractLlvmIRCommands(config: ResolcConfig, commandArgs: string[]): string[] {
-  const settings = config.settings;
+  const settings = config.settings!;
 
   commandArgs.push(`--llvm-ir`);
 
@@ -168,7 +168,7 @@ function extractLlvmIRCommands(config: ResolcConfig, commandArgs: string[]): str
 
 function extractStandardJSONCommands(config: ResolcConfig, commandArgs: string[]): string[] {
 
-  const settings = config.settings;
+  const settings = config.settings!;
 
   commandArgs.push(`--standard-json`);
 
@@ -223,7 +223,7 @@ function extractStandardJSONCommands(config: ResolcConfig, commandArgs: string[]
 }
 
 function extractCombinedJSONCommands(config: ResolcConfig, commandArgs: string[]): string[] {
-  const settings = config.settings;
+  const settings = config.settings!;
 
   commandArgs.push(`--combined-json=${settings.combinedJson}`);
 
@@ -305,7 +305,7 @@ function extractCombinedJSONCommands(config: ResolcConfig, commandArgs: string[]
 }
 
 function extractRemainingCommands(config: ResolcConfig, commandArgs: string[]): string[] {
-  const settings = config.settings; 
+  const settings = config.settings!; 
 
   if (settings.libraries) {
     commandArgs.push(`-l=${settings.libraries}`)
@@ -384,19 +384,19 @@ export function extractCommands(config: ResolcConfig): string[] {
 
   const commandArgs: string[] = [];
 
-  if (config.settings.yul) {
+  if (config.settings?.yul) {
 
     return extractYulCommands(config, commandArgs);
 
-  } else if (config.settings.llvmIR) {
+  } else if (config.settings?.llvmIR) {
     
     return extractLlvmIRCommands(config, commandArgs);
     
-  } else if (config.settings.standardJson) {
+  } else if (config.settings?.standardJson) {
 
     return extractStandardJSONCommands(config, commandArgs);
 
-  } else if (config.settings.combinedJson) {
+  } else if (config.settings?.combinedJson) {
 
     return extractCombinedJSONCommands(config, commandArgs);
     


### PR DESCRIPTION
### Description
This adds a warning when using the property `batchSize`. This is a stopgap solution until we have a more definite solution for using the `batchSize` option with relative imports.

cc: @BigTava 

Rel: #23 